### PR TITLE
Added missing quotation mark in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "magento/framework": ^100.1|^101.0|^102.0",
+    "magento/framework": "^100.1|^101.0|^102.0",
     "yireo/magento2-react": "*",
     "php": ">=7.0.0"
   },


### PR DESCRIPTION
Fixed typo that caused an issue when trying to install this module via composer:

`Skipped branch master, "3eaba06382c3b34a1ba0634624585d8680215fb6:composer.json" does not contain valid JSON
Parse error on line 15:
...magento/framework": ^100.1|^101.0|^102.0
----------------------^
Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['`